### PR TITLE
SIEW-309 Fix double escaping of post titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
-vendor/
+vendor
+dist
 group_577279265d68a.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
+vendor/
 group_577279265d68a.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+image: ubuntu1804
+stack: node 8
+build: off
+
+cache:
+  - node_modules -> package.json
+
+install:
+  - sudo apt-get update
+  - sudo apt-get -fy install composer httpie slugify
+  - npm install
+
+before_build:
+  - 'PROJECT="$(composer config name)"'
+  - 'VERSION="${APPVEYOR_REPO_TAG_NAME:-dev-$APPVEYOR_REPO_BRANCH}"'
+  - 'ARTIFACT="$(slugify $PROJECT $VERSION).zip"'
+  - 'WPR_URL="$WPR_HOST/publish.php"'
+  - 'WPR_AUTH="Authorization: Key $WPR_KEY"'
+  - 'WPR_FILES="files[]@$ARTIFACT"'
+
+build_script:
+  - rm -rf assets/dist
+  - composer config version "$VERSION"
+  - truncate -s 0 vendor/autoload.php
+  - npx --no-install gulp build
+
+after_build:
+  - zip -r "$ARTIFACT" . -x ".git/*" -x "node_modules/*" -x "vendor/*/*"
+
+deploy_script:
+  - http --form POST "$WPR_URL" "$WPR_AUTH" "$WPR_FILES" --check-status
+
+artifacts:
+  - path: '*.zip'

--- a/source/php/AcfFields/php/mod-slider.php
+++ b/source/php/AcfFields/php/mod-slider.php
@@ -23,7 +23,7 @@
                 'circle' => __('Circle slides', 'modularity'),
             ),
             'default_value' => array(
-                0 => 'default',
+                0 => __('default', 'modularity'),
             ),
             'allow_null' => 1,
             'multiple' => 0,
@@ -45,8 +45,6 @@
                 'class' => '',
                 'id' => '',
             ),
-            'multiple' => 0,
-            'allow_null' => 1,
             'choices' => array(
                 'ratio-36-7' => __('Wide (36:7)', 'modularity'),
                 'ratio-10-3' => __('Wide (10:3)', 'modularity'),
@@ -54,12 +52,14 @@
                 'ratio-4-3' => __('Square (4:3)', 'modularity'),
             ),
             'default_value' => array(
-                0 => 'ratio-16-9',
+                0 => __('ratio-16-9', 'modularity'),
             ),
+            'allow_null' => 1,
+            'multiple' => 0,
             'ui' => 0,
             'ajax' => 0,
-            'placeholder' => '',
             'return_format' => 'value',
+            'placeholder' => '',
         ),
         2 => array(
             'key' => 'field_58934110b566f',
@@ -104,20 +104,20 @@
                 'class' => '',
                 'id' => '',
             ),
-            'multiple' => 0,
-            'allow_null' => 0,
             'choices' => array(
                 'left' => __('Vänster', 'modularity'),
                 'center' => __('Centrerad', 'modularity'),
                 'right' => __('Höger', 'modularity'),
             ),
             'default_value' => array(
-                0 => 'center',
+                0 => __('center', 'modularity'),
             ),
+            'allow_null' => 0,
+            'multiple' => 0,
             'ui' => 0,
             'ajax' => 0,
-            'placeholder' => '',
             'return_format' => 'value',
+            'placeholder' => '',
         ),
         4 => array(
             'key' => 'field_58cfe67cb211b',
@@ -170,7 +170,7 @@
                 0 => array(
                     'key' => '56a5ed29398db',
                     'name' => 'image',
-                    'label' => __('Bild', 'modularity'),
+                    'label' => __('Image', 'modularity'),
                     'display' => 'block',
                     'sub_fields' => array(
                         0 => array(
@@ -261,21 +261,18 @@
                                 'class' => '',
                                 'id' => '',
                             ),
-                            'multiple' => 0,
-                            'allow_null' => 0,
                             'choices' => array(
                                 'bottom' => 'Bottom banner',
-                                'center' => 'Centered',
                             ),
                             'default_value' => array(
                                 0 => 'bottom',
                             ),
+                            'allow_null' => 0,
+                            'multiple' => 0,
                             'ui' => 0,
                             'ajax' => 0,
-                            'placeholder' => '',
                             'return_format' => 'value',
-                            'disabled' => 0,
-                            'readonly' => 0,
+                            'placeholder' => '',
                         ),
                         4 => array(
                             'key' => 'field_5702597b7d869',
@@ -292,13 +289,6 @@
                                         'value' => 'center',
                                     ),
                                 ),
-                                1 => array(
-                                    0 => array(
-                                        'field' => 'field_56e7fa230ee09',
-                                        'operator' => '==',
-                                        'value' => 'bottom',
-                                    ),
-                                ),
                             ),
                             'wrapper' => array(
                                 'width' => '',
@@ -306,10 +296,12 @@
                                 'id' => '',
                             ),
                             'default_value' => '',
+                            'maxlength' => '',
                             'placeholder' => '',
                             'prepend' => '',
                             'append' => '',
-                            'maxlength' => '',
+                            'readonly' => 0,
+                            'disabled' => 0,
                         ),
                         5 => array(
                             'key' => 'field_56ab235393f04',
@@ -333,12 +325,10 @@
                                 'id' => '',
                             ),
                             'default_value' => '',
-                            'new_lines' => 'br',
-                            'maxlength' => '',
                             'placeholder' => '',
-                            'rows' => '',
-                            'readonly' => 0,
-                            'disabled' => 0,
+                            'maxlength' => 250,
+                            'rows' => 2,
+                            'new_lines' => 'br',
                         ),
                         6 => array(
                             'key' => 'field_56fa82a2d464d',
@@ -561,94 +551,6 @@
                             'mime_types' => 'ogg',
                         ),
                         4 => array(
-                            'key' => 'field_5aaa6576ed65f',
-                            'label' => 'Show pause Icon',
-                            'name' => 'show_pause_icon',
-                            'type' => 'true_false',
-                            'instructions' => '',
-                            'required' => 0,
-                            'conditional_logic' => 0,
-                            'wrapper' => array(
-                                'width' => '33',
-                                'class' => '',
-                                'id' => '',
-                            ),
-                            'message' => 'Show pause icon',
-                            'default_value' => 1,
-                            'ui' => 0,
-                            'ui_on_text' => '',
-                            'ui_off_text' => '',
-                        ),
-                        5 => array(
-                            'key' => 'field_5aaa66deed660',
-                            'label' => 'Pause icon transparency',
-                            'name' => 'pause_icon_transparacy',
-                            'type' => 'select',
-                            'instructions' => '',
-                            'required' => 0,
-                            'conditional_logic' => array(
-                                0 => array(
-                                    0 => array(
-                                        'field' => 'field_5aaa6576ed65f',
-                                        'operator' => '==',
-                                        'value' => '1',
-                                    ),
-                                ),
-                            ),
-                            'wrapper' => array(
-                                'width' => '33',
-                                'class' => '',
-                                'id' => '',
-                            ),
-                            'choices' => array(
-                                1 => '100%',
-                                9 => '90%',
-                                8 => '80%',
-                                7 => '70%',
-                                6 => '60%',
-                                5 => '50%',
-                                4 => '40%',
-                                3 => '30%',
-                                2 => '20%',
-                            ),
-                            'default_value' => array(
-                                0 => '60%',
-                            ),
-                            'allow_null' => 0,
-                            'multiple' => 0,
-                            'ui' => 0,
-                            'ajax' => 0,
-                            'return_format' => 'value',
-                            'placeholder' => '',
-                        ),
-                        6 => array(
-                            'key' => 'field_5aaa6e50f06ba',
-                            'label' => 'Show pause icon on hover',
-                            'name' => 'show_pause_icon_on_hover',
-                            'type' => 'true_false',
-                            'instructions' => '',
-                            'required' => 0,
-                            'conditional_logic' => array(
-                                0 => array(
-                                    0 => array(
-                                        'field' => 'field_5aaa6576ed65f',
-                                        'operator' => '==',
-                                        'value' => '1',
-                                    ),
-                                ),
-                            ),
-                            'wrapper' => array(
-                                'width' => '33',
-                                'class' => '',
-                                'id' => '',
-                            ),
-                            'message' => '',
-                            'default_value' => 1,
-                            'ui' => 0,
-                            'ui_on_text' => '',
-                            'ui_off_text' => '',
-                        ),
-                        7 => array(
                             'key' => 'field_56a5ed47398dd',
                             'label' => 'Embed link',
                             'name' => 'embed_link',
@@ -672,7 +574,7 @@
                             'default_value' => '',
                             'placeholder' => '',
                         ),
-                        8 => array(
+                        5 => array(
                             'key' => 'field_56b9e2a221291',
                             'label' => 'Placeholder Image',
                             'name' => 'image',
@@ -696,7 +598,7 @@
                             'max_size' => '',
                             'mime_types' => 'png,jpg',
                         ),
-                        9 => array(
+                        6 => array(
                             'key' => 'field_56b9f3dba4f22',
                             'label' => 'Text overlay',
                             'name' => 'activate_textblock',
@@ -723,7 +625,7 @@
                             'ui_on_text' => '',
                             'ui_off_text' => '',
                         ),
-                        10 => array(
+                        7 => array(
                             'key' => 'field_56b9f3b8d7720',
                             'label' => 'Innehåll',
                             'name' => 'textblock_content',
@@ -757,7 +659,7 @@
                             'readonly' => 0,
                             'disabled' => 0,
                         ),
-                        11 => array(
+                        8 => array(
                             'key' => 'field_56e7fa620ee0a',
                             'label' => 'Text position',
                             'name' => 'textblock_position',
@@ -799,7 +701,7 @@
                             'disabled' => 0,
                             'readonly' => 0,
                         ),
-                        12 => array(
+                        9 => array(
                             'key' => 'field_56fa87ec3ace2',
                             'label' => 'Link',
                             'name' => 'link_type',
@@ -832,7 +734,7 @@
                             'allow_null' => 0,
                             'return_format' => 'value',
                         ),
-                        13 => array(
+                        10 => array(
                             'key' => 'field_56fa87fa3ace4',
                             'label' => 'Url',
                             'name' => 'link_url',
@@ -861,7 +763,7 @@
                             'default_value' => '',
                             'placeholder' => '',
                         ),
-                        14 => array(
+                        11 => array(
                             'key' => 'field_56fa88043ace5',
                             'label' => 'Sida',
                             'name' => 'link_url',
@@ -895,7 +797,7 @@
                             'multiple' => 0,
                             'allow_archives' => 1,
                         ),
-                        15 => array(
+                        12 => array(
                             'key' => 'field_56fa880c3ace6',
                             'label' => 'New window',
                             'name' => 'link_target',
@@ -1219,7 +1121,7 @@
                 'center' => __('Centrerad', 'modularity'),
                 'bottom' => __('Bottom', 'modularity'),
             ),
-            'default_value' => 'center',
+            'default_value' => __('center', 'modularity'),
             'other_choice' => 0,
             'save_other_choice' => 0,
             'allow_null' => 0,
@@ -1262,20 +1164,19 @@
                 'class' => '',
                 'id' => '',
             ),
+            'layout' => 'horizontal',
             'choices' => array(
                 'wrapAround' => __('Continues scroll (no ending slide)', 'modularity'),
                 'pageDots' => __('Pages dot navigation', 'modularity'),
                 'freeScroll' => __('No scroll snapping', 'modularity'),
                 'groupCells' => __('Group slides', 'modularity'),
-                'allowBleed' => __('Make next and previous slide partially visible', 'modularity'),
+            ),
+            'default_value' => array(
+                0 => __('wrapAround', 'modularity'),
+                1 => __('pageDots', 'modularity'),
             ),
             'allow_custom' => 0,
             'save_custom' => 0,
-            'default_value' => array(
-                0 => 'wrapAround',
-                1 => 'pageDots',
-            ),
-            'layout' => 'horizontal',
             'toggle' => 0,
             'return_format' => 'value',
         ),

--- a/source/php/AcfFields/php/mod-slider.php
+++ b/source/php/AcfFields/php/mod-slider.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 if (function_exists('acf_add_local_field_group')) {
     acf_add_local_field_group(array(
@@ -286,7 +286,7 @@
                                     0 => array(
                                         'field' => 'field_56e7fa230ee09',
                                         'operator' => '==',
-                                        'value' => 'center',
+                                        'value' => 'bottom',
                                     ),
                                 ),
                             ),

--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -224,6 +224,7 @@ class Editor extends \Modularity\Options
 
         $activeAreas = $this->getActiveAreas($template);
 
+
         // Add no active sidebars message if no active sidebars exists
         if (count($activeAreas) === 0) {
             add_meta_box(
@@ -264,7 +265,14 @@ class Editor extends \Modularity\Options
     {
         $originalTemplate = $template;
         $options = get_option('modularity-options');
-        $active = isset($options['enabled-areas'][$template]) ? $options['enabled-areas'][$template] : array();
+
+        // Use the ACF-options for module areas if activated
+        if(get_field('acf_module_areas', 'option')) {
+            $template = str_replace('.blade.php', '', $template);
+            $active = get_field($template . '_active_sidebars', 'option');
+        } else {
+            $active = isset($options['enabled-areas'][$template]) ? $options['enabled-areas'][$template] : array();
+        }
 
         self::$isEditing['template'] = $template;
 

--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -132,17 +132,13 @@ class Editor extends \Modularity\Options
      */
     public static function isPageForPostType($postId)
     {
-        $postTypes = get_post_types();
+        $postType = get_post_type($postId);
+        $option = get_option('page_for_' . $postType);
+        $pageContent = get_option('page_for_' . $postType . '_content');
 
-        foreach ($postTypes as $postType) {
-            $option = get_option('page_for_' . $postType);
-            $pageContent = get_option('page_for_' . $postType . '_content');
-
-            if ($option && $option === $postId && !$pageContent) {
-                return $postType;
-            }
+        if ($option && $option === $postId && !$pageContent) {
+            return $postType;
         }
-
         return false;
     }
 
@@ -223,7 +219,6 @@ class Editor extends \Modularity\Options
         $sidebars = null;
 
         $activeAreas = $this->getActiveAreas($template);
-
 
         // Add no active sidebars message if no active sidebars exists
         if (count($activeAreas) === 0) {
@@ -378,7 +373,6 @@ class Editor extends \Modularity\Options
      */
     public static function getPostModules($postId)
     {
-
         //Declarations
         $modules = array();
         $retModules = array();
@@ -427,7 +421,7 @@ class Editor extends \Modularity\Options
             'post_status' => $postStatuses
         ));
 
-        //var_dump($modulesPosts);
+        //error_log(print_r($modulesPosts, true));
 
         // Add module id's as keys in the array
         if (!empty($modulesPosts)) {

--- a/source/php/Editor.php
+++ b/source/php/Editor.php
@@ -421,8 +421,6 @@ class Editor extends \Modularity\Options
             'post_status' => $postStatuses
         ));
 
-        //error_log(print_r($modulesPosts, true));
-
         // Add module id's as keys in the array
         if (!empty($modulesPosts)) {
             foreach ($modulesPosts as $module) {

--- a/source/php/Helper/Post.php
+++ b/source/php/Helper/Post.php
@@ -32,7 +32,7 @@ class Post
      * Gets the post template of the current editor page
      * @return string Template slug
      */
-    public static function getPostTemplate($id = null)
+    public static function getPostTemplate($id = null, $trim = false)
     {
         if ($archive = self::isArchive()) {
             return $archive;
@@ -64,6 +64,8 @@ class Post
         if (!$template) {
             $template = self::detectCoreTemplate($post);
         }
+
+        $template = $trim ? str_replace('.blade.php', '', $template) : $template;
 
         return $template;
     }

--- a/source/php/Helper/React.php
+++ b/source/php/Helper/React.php
@@ -6,6 +6,10 @@ class React
 {
     public static function enqueue($version = false)
     {
+        if (isset($GLOBALS['wp_version']) && (int) $GLOBALS['wp_version'] >= 5) {
+            return;
+        }
+
         // Use minified libraries if SCRIPT_DEBUG is turned off
         $suffix = (defined('DEV_MODE') && DEV_MODE) ? 'development' : 'production.min';
 

--- a/source/php/Module/InheritPost/views/inheritposts.blade.php
+++ b/source/php/Module/InheritPost/views/inheritposts.blade.php
@@ -4,7 +4,7 @@
         <h1>{{ $module->post_title }}</h1>
     @endif
 
-    <h2>{{ apply_filters('the_title', $inherit->post_title) }}</h2>
+    <h2>{!! apply_filters('the_title', $inherit->post_title) !!}</h2>
     {!! apply_filters('the_content', $inherit->post_content) !!}
 </article>
 @endif

--- a/source/php/Module/Posts/views/expandable-list.blade.php
+++ b/source/php/Module/Posts/views/expandable-list.blade.php
@@ -65,6 +65,11 @@
                 @endif
             </label>
             <div class="accordion-content">
+                <noscript>
+                    <style type="text/css">
+                        .accordion-content { display: block; }
+                    </style>
+                </noscript>
                 <article>
                     <?php echo apply_filters('the_content', $post->post_content); ?>
                 </article>

--- a/source/php/Module/Posts/views/expandable-list.blade.php
+++ b/source/php/Module/Posts/views/expandable-list.blade.php
@@ -34,7 +34,7 @@
                     <span class="accordion-table">
                     @if (isset($post->column_values) && !empty($post->column_values))
                         @if ($posts_hide_title_column)
-                        <span class="column-header">{{ apply_filters('the_title', $post->post_title) }}</span>
+                        <span class="column-header">{!! apply_filters('the_title', $post->post_title) !!}</span>
                         @endif
 
                         @if (is_array($posts_list_column_titles))

--- a/source/php/Module/Posts/views/grid.blade.php
+++ b/source/php/Module/Posts/views/grid.blade.php
@@ -29,7 +29,7 @@
                     @endif
 
                     @if (in_array('title', $posts_fields))
-                    <h3 class="post-title">{{ apply_filters('the_title', $post->post_title) }}</h3>
+                    <h3 class="post-title">{!! apply_filters('the_title', $post->post_title) !!}</h3>
                     @endif
                 </div>
 

--- a/source/php/Module/Posts/views/index.blade.php
+++ b/source/php/Module/Posts/views/index.blade.php
@@ -27,7 +27,7 @@
 
             <div class="box-content">
                 @if (in_array('title', $posts_fields))
-                <h5 class="box-index-title link-item">{{ apply_filters('the_title', $post->post_title) }}</h5>
+                <h5 class="box-index-title link-item">{!! apply_filters('the_title', $post->post_title) !!}</h5>
                 @endif
 
                 @if (in_array('excerpt', $posts_fields))

--- a/source/php/Module/Posts/views/items.blade.php
+++ b/source/php/Module/Posts/views/items.blade.php
@@ -27,7 +27,7 @@
 
                 <div class="box-content">
                     @if (in_array('title', $posts_fields))
-                    <h5 class="link-item link-item-light">{{ apply_filters('the_title', $post->post_title) }}</h5>
+                    <h5 class="link-item link-item-light">{!! apply_filters('the_title', $post->post_title) !!}</h5>
                     @endif
 
                     @if (in_array('date', $posts_fields) && $posts_data_source !== 'input')

--- a/source/php/Module/Posts/views/list.blade.php
+++ b/source/php/Module/Posts/views/list.blade.php
@@ -15,7 +15,7 @@
                     <a href="{{ $posts_data_source === 'input' ? $post->permalink : get_permalink($post->ID) }}">
                 @endif
                     @if (in_array('title', $posts_fields))
-                        <span class="link-item title">{{ apply_filters('the_title', $post->post_title) }}</span>
+                        <span class="link-item title">{!! apply_filters('the_title', $post->post_title) !!}</span>
                     @endif
 
                     @if (in_array('date', $posts_fields) && $posts_data_source !== 'input')

--- a/source/php/Module/Posts/views/news.blade.php
+++ b/source/php/Module/Posts/views/news.blade.php
@@ -30,7 +30,7 @@
 
             <div class="box-content">
                 @if (in_array('title', $posts_fields))
-                <h3 class="text-highlight">{{ apply_filters('the_title', $post->post_title) }}</h3>
+                <h3 class="text-highlight">{!! apply_filters('the_title', $post->post_title) !!}</h3>
                 @endif
 
                 @if (in_array('excerpt', $posts_fields))

--- a/source/php/Options/AcfFields/acf-module-restrictions.php
+++ b/source/php/Options/AcfFields/acf-module-restrictions.php
@@ -189,7 +189,7 @@ function generateFields() {
         );
         array_push($template_fields, $active_sidebars);
 
-        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+        $template_sidebars = get_field($id . '_active_sidebars', 'option');
         if($template_sidebars) {
             foreach ($template_sidebars as $sidebar) {
                 $sidebar_modules = array(

--- a/source/php/Options/AcfFields/acf-module-restrictions.php
+++ b/source/php/Options/AcfFields/acf-module-restrictions.php
@@ -1,0 +1,231 @@
+<?php
+
+if( function_exists('acf_add_local_field_group') ) {
+    acf_add_local_field_group(array(
+	'key' => 'group_5b2908801bd05',
+	'title' => __('Sidebar & Module Restrictions', 'modularity'),
+	'fields' => generateFields(),
+	'location' => array(
+	    array(
+		array(
+		    'param' => 'options_page',
+		    'operator' => '==',
+		    'value' => 'acf-options-restrictive-options',
+		),
+	    ),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => '',
+	'active' => 1,
+	'description' => '',
+    ));
+
+    acf_add_local_field_group(array(
+	'key' => 'group_5b2908801bd08',
+	'title' => __('Settings', 'modularity'),
+	'fields' => array(
+	    array(
+		'key' => 'field_acf_module_areas',
+		'label' => __('Template Areas', 'modularity'),
+		'name' => 'acf_module_areas',
+		'type' => 'true_false',
+		'instructions' => '',
+		'required' => 0,
+		'conditional_logic' => 0,
+		'wrapper' => array(
+		    'width' => '',
+		    'class' => '',
+		    'id' => '',
+		),
+		'message' => __(
+                    'Checking this will override the default module area settings.',
+                    'modularity'
+                ),
+		'default_value' => 0,
+		'ui' => 1,
+		'ui_on_text' => '',
+		'ui_off_text' => '',
+	    ),
+	    array(
+		'key' => 'field_module_restrictions',
+		'label' => __('Module Restrictions', 'modularity'),
+		'name' => 'acf_module_restrictions',
+		'type' => 'true_false',
+		'instructions' => '',
+		'required' => 0,
+		'conditional_logic' => 0,
+		'wrapper' => array(
+		    'width' => '',
+		    'class' => '',
+		    'id' => '',
+		),
+		'message' => __(
+                    'Checking this will filter the default module settings for each template.',
+                    'modularity'
+                ),
+		'default_value' => 0,
+		'ui' => 1,
+		'ui_on_text' => '',
+		'ui_off_text' => '',
+	    )
+	),
+	'location' => array(
+	    array(
+		array(
+		    'param' => 'options_page',
+		    'operator' => '==',
+		    'value' => 'acf-options-restrictive-options',
+		),
+	    ),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+        'hide_on_screen' => '',
+	'active' => 1,
+	'description' => '',
+    ));
+}
+
+/**
+ * Get registered sidebars and returns an assoc
+ *
+ * @return array Sidebar Options
+ */
+function getSidebars()
+{
+    global $wp_registered_sidebars;
+    $sidebar_options = array();
+
+    foreach ( $wp_registered_sidebars as $sidebar ){
+        $sidebar_options[$sidebar['id']] = $sidebar['name'];
+    }
+    return $sidebar_options;
+}
+
+/**
+ * Get available templates of the theme
+ *
+ * @return array Available Templates
+ */
+function getTemplates()
+{
+    $coreTemplates = \Modularity\Helper\Wp::getCoreTemplates();
+    $coreTemplates = apply_filters('Modularity/CoreTemplatesInTheme', $coreTemplates);
+    $customTemplates = wp_get_theme()->get_page_templates();
+
+    $templates = array_merge($coreTemplates, $customTemplates);
+
+    return $templates;
+}
+
+/**
+ * Generate or load ACF option fields for each available template
+ *
+ * @return array Option Fields corresponding to each template
+ */
+function generateFields() {
+    $template_fields = array();
+    $all_sidebars = getSidebars();
+    $available_modules = \Modularity\ModuleManager::$enabled;
+
+    foreach(getTemplates() as $id => $template) {
+        $id = str_replace('.blade.php', '', $id);
+        $accordion = array(
+            'key' => 'field_' . $id,
+            'label' => __($template, 'modularity'),
+            'name' => '',
+            'type' => 'accordion',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'open' => 0,
+            'multi_expand' => 0,
+            'endpoint' => 0,
+        );
+        array_push($template_fields, $accordion);
+
+        $active_sidebars = array(
+            'key' => 'field_' . $id . '-sidebars',
+            'label' => __('Active Sidebars', 'modularity'),
+            'name' => $id . '_active_sidebars',
+            'type' => 'select',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => array(
+                array(
+                    array(
+                        'field' => 'field_acf_module_areas',
+                        'operator' => '==',
+                        'value' => '1',
+                    ),
+                ),
+            ),
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'choices' => $all_sidebars,
+            'default_value' => array(
+            ),
+            'allow_null' => 0,
+            'multiple' => 1,
+            'ui' => 1,
+            'return_format' => 'value',
+            'ajax' => 0,
+            'placeholder' => '',
+        );
+        array_push($template_fields, $active_sidebars);
+
+        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+        if($template_sidebars) {
+            foreach ($template_sidebars as $sidebar) {
+                $sidebar_modules = array(
+	            'key' => 'field_' . $id . $sidebar,
+		    'label' => __($all_sidebars[$sidebar], 'modularity'),
+		    'name' => $id . '-' . $sidebar,
+		    'type' => 'select',
+		    'instructions' => '',
+		    'required' => 0,
+		    'conditional_logic' => array(
+			array(
+			    array(
+				'field' => 'field_module_restrictions',
+				'operator' => '==',
+				'value' => '1',
+			    ),
+			),
+		    ),
+		    'wrapper' => array(
+			'width' => '',
+			'class' => '',
+			'id' => '',
+		    ),
+		    'choices' => $available_modules,
+		    'default_value' => array(
+		    ),
+		    'allow_null' => 0,
+		    'multiple' => 1,
+		    'ui' => 1,
+		    'return_format' => 'array',
+		    'ajax' => 0,
+		    'placeholder' => '',
+		);
+		array_push($template_fields, $sidebar_modules);
+	    }
+	}
+    }
+    return $template_fields;
+}

--- a/source/php/Options/General.php
+++ b/source/php/Options/General.php
@@ -25,6 +25,91 @@ class General extends \Modularity\Options
                 'options.php?page=modularity-editor&id=search'
             );
         });
+
+        acf_add_options_sub_page(array(
+            'page_title'    => __('Restrictive Options', 'modularity'),
+            'menu_title'    => __('Restrictive Options', 'modularity'),
+            'parent_slug'   => 'modularity',
+            'capability'    => 'administrator',
+            'redirect'      => false,
+            'icon_url'      => ''
+        ));
+
+        /**
+         * Initialize ACF fields for restrictive options. This needs to be
+         * called after the Add() action in the municipio template helper in
+         * order to find custom templates. (Thereby the priority of 1000).
+         */
+        add_action(
+            'init',
+            function() {
+                $acfPath = 'source/php/Options/AcfFields/acf-module-restrictions.php';
+	        include MODULARITY_PATH . $acfPath;
+	    },
+	    1000
+        );
+
+	if(get_field('acf_module_restrictions', 'option')) {
+	    add_filter(
+		'Modularity/Editor/SidebarIncompability',
+		array($this, 'sidebarIncompatibility'),
+		20,
+		2
+	    );
+	    add_action('edit_form_top', function () {
+		\Modularity\ModuleManager::$enabled = $this->moduleRestriction();
+	    });
+	}
+    }
+
+    /**
+     * Filters the sidebar incompatibility list based on the restrictive
+     * options page.
+     *
+     * @return array Module Specification
+     */
+    public function sidebarIncompatibility($moduleSpecification, $modulePostType) {
+        $template = \Modularity\Helper\Post::getPostTemplate(null, true);
+        $template_sidebars = get_field($template . '_active_sidebars', 'option');
+
+	if($template_sidebars) {
+	    $sidebarIncompatibilities = array_flip($template_sidebars);
+
+	    foreach($template_sidebars as $sidebar) {
+		$modules = get_field($template . '-' . $sidebar, 'option');
+		foreach($modules as $module) {
+		    if($modulePostType == $module['label']) {
+			unset($sidebarIncompatibilities[$sidebar]);
+		    }
+		}
+	    }
+	    $moduleSpecification['sidebar_incompability'] = array_keys($sidebarIncompatibilities);
+	}
+	return $moduleSpecification;
+    }
+
+    /**
+     * Decides what modules are available for the current template
+     * based on the restrictive options page (if enabled).
+     *
+     * @return array Enabled modules
+     */
+    public function moduleRestriction() {
+	$enabledMods = array();
+	$template = \Modularity\Helper\Post::getPostTemplate(null, true);
+	$sidebars = get_field($template . '_active_sidebars', 'option');
+
+	if(count($sidebars) > 0) {
+	    foreach($sidebars as $sidebar) {
+		$modules = get_field($template . '-' . $sidebar, 'option');
+		if($modules) {
+		    foreach($modules as $module) {
+			array_push($enabledMods, $module['label']);
+		    }
+		}
+	    }
+	}
+	return $enabledMods;
     }
 
     /**
@@ -33,68 +118,68 @@ class General extends \Modularity\Options
      */
     public function addMetaBoxes()
     {
-        // Publish
-        add_meta_box(
-            'modularity-mb-publish',
-            __('Save options', 'modularity'),
-            function () {
-                $templatePath = \Modularity\Helper\Wp::getTemplate('publish', 'options/partials');
-                include $templatePath;
-            },
-            $this->screenHook,
-            'side'
-        );
+	// Publish
+	add_meta_box(
+	    'modularity-mb-publish',
+	    __('Save options', 'modularity'),
+	    function () {
+		$templatePath = \Modularity\Helper\Wp::getTemplate('publish', 'options/partials');
+		include $templatePath;
+	    },
+	    $this->screenHook,
+	    'side'
+	);
 
-        // Core options
-        add_meta_box(
-            'modularity-mb-core-options',
-            __('Core options', 'modularity'),
-            function () {
-                $templatePath = \Modularity\Helper\Wp::getTemplate('core-options', 'options/partials');
-                include $templatePath;
-            },
-            $this->screenHook,
-            'normal'
-        );
+	// Core options
+	add_meta_box(
+	    'modularity-mb-core-options',
+	    __('Core options', 'modularity'),
+	    function () {
+		$templatePath = \Modularity\Helper\Wp::getTemplate('core-options', 'options/partials');
+		include $templatePath;
+	    },
+	    $this->screenHook,
+	    'normal'
+	);
 
-        if (has_action('Modularity/Options/Module')) {
-            add_meta_box(
-                'modularity-mb-module-options',
-                __('Module options', 'modularity'),
-                function () {
-                    do_action('Modularity/Options/Module');
-                },
-                $this->screenHook,
-                'normal'
-            );
-        }
+	if (has_action('Modularity/Options/Module')) {
+	    add_meta_box(
+		'modularity-mb-module-options',
+		__('Module options', 'modularity'),
+		function () {
+		    do_action('Modularity/Options/Module');
+		},
+		$this->screenHook,
+		'normal'
+	    );
+	}
 
-        // Modules
-        add_meta_box(
-            'modularity-mb-post-types',
-            __('Post types', 'modularity'),
-            array($this, 'metaBoxPostTypes'),
-            $this->screenHook,
-            'normal'
-        );
+	// Modules
+	add_meta_box(
+	    'modularity-mb-post-types',
+	    __('Post types', 'modularity'),
+	    array($this, 'metaBoxPostTypes'),
+	    $this->screenHook,
+	    'normal'
+	);
 
-        // Templates and areas
-        add_meta_box(
-            'modularity-mb-template-areas',
-            __('Template areas', 'modularity'),
-            array($this, 'metaBoxTemplateAreas'),
-            $this->screenHook,
-            'normal'
-        );
+	// Templates and areas
+	add_meta_box(
+	    'modularity-mb-template-areas',
+	    __('Template areas', 'modularity'),
+	    array($this, 'metaBoxTemplateAreas'),
+	    $this->screenHook,
+	    'normal'
+	);
 
-        // Modules
-        add_meta_box(
-            'modularity-mb-modules',
-            __('Modules', 'modularity'),
-            array($this, 'metaBoxModules'),
-            $this->screenHook,
-            'normal'
-        );
+	// Modules
+	add_meta_box(
+	    'modularity-mb-modules',
+	    __('Modules', 'modularity'),
+	    array($this, 'metaBoxModules'),
+	    $this->screenHook,
+	    'normal'
+	);
     }
 
     /**
@@ -103,20 +188,19 @@ class General extends \Modularity\Options
      */
     public function metaBoxTemplateAreas()
     {
-        global $wp_registered_sidebars;
-        global $modularityOptions;
+	global $wp_registered_sidebars;
+	global $modularityOptions;
 
-        usort($wp_registered_sidebars, function ($a, $b) {
-            return $a['name'] > $b['name'];
-        });
+	usort($wp_registered_sidebars, function ($a, $b) {
+	    return $a['name'] > $b['name'];
+	});
 
-        $coreTemplates = \Modularity\Helper\Wp::getCoreTemplates();
-        $coreTemplates = apply_filters('Modularity/CoreTemplatesInTheme', $coreTemplates);
-        $customTemplates = get_page_templates();
+	$coreTemplates = \Modularity\Helper\Wp::getCoreTemplates();
+	$coreTemplates = apply_filters('Modularity/CoreTemplatesInTheme', $coreTemplates);
+	$customTemplates = get_page_templates();
+	$templates = array_merge($coreTemplates, $customTemplates);
 
-        $templates = array_merge($coreTemplates, $customTemplates);
-
-        include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-template-areas.php';
+	include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-template-areas.php';
     }
 
     /**
@@ -125,33 +209,33 @@ class General extends \Modularity\Options
      */
     public function metaBoxPostTypes()
     {
-        global $modularityOptions;
-        $enabled = isset($modularityOptions['enabled-post-types']) && is_array($modularityOptions['enabled-post-types']) ? $modularityOptions['enabled-post-types'] : array();
+	global $modularityOptions;
+	$enabled = isset($modularityOptions['enabled-post-types']) && is_array($modularityOptions['enabled-post-types']) ? $modularityOptions['enabled-post-types'] : array();
 
-        $postTypes = array_filter(get_post_types(), function ($item) {
-            $disallowed = array_merge(
-                array_keys(\Modularity\ModuleManager::$available),
-                array(
-                    'attachment',
-                    'revision',
-                    'nav_menu_item',
-                    'custom_css',
-                    'customize_changeset'
-                )
-            );
+	$postTypes = array_filter(get_post_types(), function ($item) {
+	    $disallowed = array_merge(
+		array_keys(\Modularity\ModuleManager::$available),
+		array(
+		    'attachment',
+		    'revision',
+		    'nav_menu_item',
+		    'custom_css',
+		    'customize_changeset'
+		)
+	    );
 
-            if (in_array($item, $disallowed)) {
-                return false;
-            }
+	    if (in_array($item, $disallowed)) {
+		return false;
+	    }
 
-            if (substr($item, 0, 4) == 'acf-') {
-                return false;
-            }
+	    if (substr($item, 0, 4) == 'acf-') {
+		return false;
+	    }
 
-            return true;
-        });
+	    return true;
+	});
 
-        include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-post-types.php';
+	include MODULARITY_TEMPLATE_PATH . 'options/partials/modularity-post-types.php';
     }
 
     /**
@@ -160,16 +244,16 @@ class General extends \Modularity\Options
      */
     public function metaBoxModules()
     {
-        $available = \Modularity\ModuleManager::$available;
+	$available = \Modularity\ModuleManager::$available;
 
-        uasort($available, function ($a, $b) {
-            return strcmp($a['labels']['name'], $b['labels']['name']);
-        });
+	uasort($available, function ($a, $b) {
+	    return strcmp($a['labels']['name'], $b['labels']['name']);
+	});
 
-        global $modularityOptions;
-        $enabled = isset($modularityOptions['enabled-modules']) && is_array($modularityOptions['enabled-modules']) ? $modularityOptions['enabled-modules'] : array();
+	global $modularityOptions;
+	$enabled = isset($modularityOptions['enabled-modules']) && is_array($modularityOptions['enabled-modules']) ? $modularityOptions['enabled-modules'] : array();
 
-        $templatePath = \Modularity\Helper\Wp::getTemplate('modules', 'options/partials');
-        include $templatePath;
+	$templatePath = \Modularity\Helper\Wp::getTemplate('modules', 'options/partials');
+	include $templatePath;
     }
 }


### PR DESCRIPTION
Post title filters in WordPress change certain characters to HTML-encoded variants. These were sometimes also escaped by Blade, resulting in the HTML-encoded variants being visible to end users.

The post title filters do not escape HTML tags from the title. While this could cause issues, the HTML-encoded characters makes it so that titles cannot be escaped without first disabling some of the built-in
post title filters.

Post titles are usually not escaped in Modularity, so this commit just makes that the case in all other places as well.